### PR TITLE
Fix admin form

### DIFF
--- a/image_segmentation.module
+++ b/image_segmentation.module
@@ -14,12 +14,12 @@
 function image_segmentation_menu()
 {
     return array(
-        'admin/islandora/segmentation' => array(
+        'admin/islandora/solution_pack_config/segmentation' => array(
             'title' => 'Image Segmentaion Module',
             'description' => 'Configure the Image Segmentation solution pack.',
             'page callback' => 'drupal_get_form',
             'access arguments' => array('administer site configuration'),
-            'page arguments' => array('image_segmentation_admin'),
+            'page arguments' => array('image_segmentation_admin_form'),
             'file' => 'includes/admin.form.inc',
             'type' => MENU_NORMAL_ITEM,
         ),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -10,33 +10,33 @@
   * @return array
   *   Returns admin form.
   */
-  function islandora_api_admin_settings_form() {
+  function image_segmentation_admin_form() {
     $form = array(
       "api_host" => array(
         '#type' => 'textfield',
         '#title' => t('API Host'),
-        '#default_value' => '',
+        '#default_value' => variable_get('api_host', 'localhost'),
         '#description' => t('Host name for API'),
         '#size' => 50,
       ),
       "api_port" => array(
         '#type' => 'textfield',
         '#title' => t('API Port'),
-        '#default_value' => '',
+        '#default_value' => variable_get('api_port', '8008'),
         '#description' => t('Port number for API'),
         '#size' => 50,
       ),
       "api_key" => array(
-        '#type' => 'textfield',
+        '#type' => 'password',
         '#title' => t('API Key'),
-        '#default_value' => '',
+        '#default_value' => variable_get('api_key', 'abc'),
         '#description' => t('Key for API'),
         '#size' => 50,
       ),
       "confidence_threshold" => array(
         '#type' => 'textfield',
         '#title' => t('API Confidence Threshold'),
-        '#default_value' => '',
+        '#default_value' => variable_get('confidense_threshold', '60.0'),
         '#description' => t('Confidence Threshold for API ML results'),
         '#size' => 50,
       ),


### PR DESCRIPTION
Fixes the admin form and moves it to the correct location.

- The admin form can now be found in the solutionpack menu.
-  Fixed function name for admin form.
- Admin form now remembers settings and does not reset the values.