### PR TITLE
Generate segments

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,6 +51,8 @@ Vagrant.configure("2") do |config|
    end
 
   config.vm.provision :shell, inline: "drush --root=/var/www/drupal/ en -u 1 -y composer_manager || echo '##### PLEASE IGNORE THE ERRORS #####' ", :privileged => false
+  config.vm.provision :shell, inline: "drush --root=/var/www/drupal/ vset api_host $1", :args => $newspaper_navigator_host, :privileged => false
+  config.vm.provision :shell, inline: "drush --root=/var/www/drupal/ vset api_port $1", :args => $newspaper_navigator_port, :privileged => false
 
   unless  $multiple_vms.eql? "FALSE"
     # Fires last to modify one last change.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,8 @@ $memory = ENV.fetch("ISLANDORA_VAGRANT_MEMORY", "3000")
 $hostname = ENV.fetch("ISLANDORA_VAGRANT_HOSTNAME", "islandora")
 $forward = ENV.fetch("ISLANDORA_VAGRANT_FORWARD", "TRUE")
 $multiple_vms  = ENV.fetch("ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS", "FALSE")
+$newspaper_navigator_host  = ENV.fetch("NEWSPAPER_NAVIGATOR_HOST", "localhost")
+$newspaper_navigator_port  = ENV.fetch("NEWSPAPER_NAVIGATOR_PORT", "8008")
 
 Vagrant.configure("2") do |config|
 
@@ -47,6 +49,8 @@ Vagrant.configure("2") do |config|
      config.vm.network :private_network, ip: "33.33.33.10"
 
    end
+
+  config.vm.provision :shell, inline: "drush --root=/var/www/drupal/ en -u 1 -y composer_manager || echo '##### PLEASE IGNORE THE ERRORS #####' ", :privileged => false
 
   unless  $multiple_vms.eql? "FALSE"
     # Fires last to modify one last change.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ $memory = ENV.fetch("ISLANDORA_VAGRANT_MEMORY", "3000")
 $hostname = ENV.fetch("ISLANDORA_VAGRANT_HOSTNAME", "islandora")
 $forward = ENV.fetch("ISLANDORA_VAGRANT_FORWARD", "TRUE")
 $multiple_vms  = ENV.fetch("ISLANDORA_VAGRANT_MULTIPLE_ISLANDORAS", "FALSE")
-$newspaper_navigator_host  = ENV.fetch("NEWSPAPER_NAVIGATOR_HOST", "localhost")
+$newspaper_navigator_host  = ENV.fetch("NEWSPAPER_NAVIGATOR_HOST", "10.0.2.2")
 $newspaper_navigator_port  = ENV.fetch("NEWSPAPER_NAVIGATOR_PORT", "8008")
 
 Vagrant.configure("2") do |config|

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "http://github.com/Islandora-Image-Segmentation/Newspaper-Navigator-API-PHP-Client-Library"
+    }
+  ],
+  "require": {
+    "islandora_image_segmentation/php_client_library": "dev-dev"
+  }
+}

--- a/includes/generate_segment.form.inc
+++ b/includes/generate_segment.form.inc
@@ -20,6 +20,11 @@ function image_segmentation_generate_segment_form(array $form, array &$form_stat
       '#type' => 'item',
       '#description' => t('You must have the <b>Image Segmentation API</b> confugured to extract image segments.'),
     ],
+    'force' => [
+      '#type' => 'checkbox',
+      '#title' => t('Force regeneration'),
+
+    ],
     'submit' => [
       '#disabled' => !$can_segment,
       '#type' => 'submit',
@@ -43,7 +48,7 @@ function image_segmentation_generate_segment_form(array $form, array &$form_stat
 function image_segmentation_generate_segment_form_submit(array $form, array &$form_state) {
   module_load_include('inc', 'image_segmentation', 'includes/utilities');
   $object = islandora_object_load($form_state['values']['pid']);
-  if (image_segmentation_extract_segments($object)) {
+  if (image_segmentation_extract_segments($object, $form_state['values']['force'])) {
     drupal_set_message(t('Successfully extracted segments.'));
   }
   else {

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1,17 +1,50 @@
 <?php
 
+use NewspaperNavigator\SegmentationClient;
+use NewspaperNavigator\ExtractedSegment;
+
 /**
- * Gets all the segments in the given paged content object.
+ * Gets all the segments in the given newspaper page.
  *
  * @param AbstractObject $object
  *   The newspaper page to fetch the pages from.
  *
  * @return array
- *   All the segments in the given newspaper page. Ordered by sequence
- *   number. Each an array containing info.
+ *   All the segments in the given newspaper page.
  */
 function image_segmentation_get_segments(AbstractObject $object) {
-  return [$object, $object, $object];
+
+  $repository = $object->repository;
+  $get_object = function ($id) use (&$repository) {
+    return $repository->getObject($id);
+  };
+  return array_map($get_object, image_segmentation_get_segment_pids($object));
+}
+
+/**
+ * Gets all the segments in the given newspaper page.
+ *
+ * @param AbstractObject $object
+ *   The newspaper page to fetch the pages from.
+ *
+ * @return array
+ *   An array of the PIDs of the segments in the page.
+ */
+function image_segmentation_get_segment_pids(AbstractObject $object) {
+  $query = <<<EOQ
+  PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
+  SELECT ?pid
+  FROM <#ri>
+  WHERE {
+    ?pid <islandora-rels-ext:isSegmentOf> <info:fedora/$object->id>
+  }
+EOQ;
+
+  $results = $object->repository->ri->sparqlQuery($query);
+  $map = function ($e) {
+    return $e['pid']['value'];
+  };
+  return array_map($map, $results);
 }
 
 /**
@@ -57,7 +90,7 @@ function image_segmentation_can_segment(AbstractObject $object) {
 
 
 /**
- * Extracts segments from a newspaper page
+ * Extracts segments from a newspaper page.
  *
  * @param \AbstractObject $object
  *  The page object that the segments will be extracted from.
@@ -65,27 +98,107 @@ function image_segmentation_can_segment(AbstractObject $object) {
  * @return bool
  *   Returns TRUE on success and FALSE on failure.
  */
-function image_segmentation_extract_segments(AbstractObject $object) {
+function image_segmentation_extract_segments(AbstractObject $object, bool $force = FALSE) {
   $repository = islandora_get_tuque_connection()->repository;
+  $existing_segments = image_segmentation_get_segment_pids($object);
+  if ($force) {
+    foreach ($existing_segments as &$segment) {
+      $repository->purgeObject($segment);
+    }
+  }
+  elseif (count($existing_segments) > 0) {
+    drupal_set_message("Segments already exist.", "error");
+    return FALSE;
+  }
 
-  $segment = $repository->constructObject("{$object->id}-01");
-  $segment->label = "{$object->id}-01";
-  $segment->relationships->add(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', $object->id);
-  $segment->relationships->add(FEDORA_RELS_EXT_URI, 'isSegmentOf', $object->id);
-  $segment->models = ['islandora:segmentedImageCModel'];
+  $api_host = variable_get("api_host");
+  $api_port = variable_get("api_port");
+  $api_timeout = variable_get("api_timeout", 60.0);
+  $client = new SegmentationClient("{$api_host}:{$api_port}/api/", $api_timeout);
 
-  $datastream = $segment->constructDatastream('OBJ', 'M');
-  $datastream->label = 'OBJ';
-  $datastream->mimetype = $object['OBJ']->mimetype;
-  $datastream->content = $object['OBJ']->content;
-  $segment->ingestDatastream($datastream);
+  $filename = image_segmentation_get_uploaded_file($object['OBJ']);
+  $response = $client->segmentFile($filename);
+  if ($response->status_code != 0) {
+    drupal_set_message("Newspaper Navigator API error:\n{$response->error_message}", "error");
+    return FALSE;
+  }
 
-  $ocr = $segment->constructDatastream('OCR', 'M');
-  $ocr->label = 'OCR text';
-  $ocr->mimetype = 'text/plain';
-  $ocr->content = $object['OCR']->content;
-  $segment->ingestDatastream($ocr);
+  for ($i = 1; $i <= $response->segment_count; $i++) {
+    $ingested = image_segmentation_ingest_segment($response->segments[$i - 1], $i, $object, $filename);
+    if (!isset($ingested)) {
+      drupal_set_message("Failed to ingest segment", "error");
+      return FALSE;
+    }
+    drupal_set_message("Ingested <a href='/islandora/object/{$ingested->id}'>$ingested->id</a>");
+  }
+  drupal_unlink($filename);
 
-  $repository->ingestObject($segment);
-  return TRUE && $segment;
+  return TRUE;
+}
+
+/**
+ * Fetches the upload image file from Fedora, and saves it to a temp location.
+ *
+ * @param AbstractDatastream $datastream
+ *   The object to fetch the uploaded image file from.
+ *
+ * @return string
+ *   The file path to the temp file if successful, FALSE otherwise.
+ */
+function image_segmentation_get_uploaded_file(AbstractDatastream $datastream) {
+  $mime_detector = new MimeDetect();
+  $ext = $mime_detector->getExtension($datastream->mimeType);
+  $filename = file_create_filename(str_replace(':', '_', "{$datastream->parent->id}_{$datastream->id}.{$ext}"), 'temporary://');
+  $datastream->getContent($filename);
+  return $filename;
+}
+
+
+/**
+ * Ingests an extracted segment
+ *
+ * @param \NewspaperNavigator\ExtractedSegment $extractedSegment
+ *  THe segment to ingest
+ * @param int $seq
+ *   The sequence number of the segment
+ * @param \AbstractObject $parent
+ *   The parent of the extracted segment
+ * @param string $file
+ *   The file to crop the segment from
+ *
+ * @return \AbstractObject
+ *  The extracted segment
+ * @throws \ImagickException
+ */
+function image_segmentation_ingest_segment(ExtractedSegment &$extractedSegment, int $seq, AbstractObject $parent, string $file) {
+    $id = sprintf("%s-%02d", $parent->id, $seq);
+    $repository = $parent->repository;
+    $segment = $repository->constructObject($id);
+    $segment->label = $id;
+    $segment->relationships->add(FEDORA_RELS_EXT_URI, 'isMemberOfCollection', $parent->id);
+    $segment->relationships->add(ISLANDORA_RELS_EXT_URI, 'isSegmentOf', $parent->id);
+    $segment->relationships->add(ISLANDORA_RELS_INT_URI, 'hasImageCategory', $extractedSegment->classification);
+    $segment->models = ['islandora:segmentedImageCModel'];
+
+    $image = new Imagick($file);
+    $cropped = \NewspaperNavigator\cropImage($image, $extractedSegment->bounding_box);
+    $mime_detector = new MimeDetect();
+    $ext = $mime_detector->getExtension($image->getImageMimeType());
+    $cropped_file = file_create_filename("cropped.{$ext}", 'temporary://');
+    $cropped->writeImage(drupal_realpath($cropped_file));
+
+    $datastream = $segment->constructDatastream('OBJ', 'M');
+    $datastream->label = 'OBJ';
+    $datastream->mimetype = $cropped->getImageMimeType();
+    $datastream->setContentFromFile($cropped_file);
+    $segment->ingestDatastream($datastream);
+
+    $ocr = $segment->constructDatastream('OCR', 'M');
+    $ocr->label = 'OCR text';
+    $ocr->mimetype = 'text/plain';
+    $ocr->setContentFromString($extractedSegment->ocr_text);
+    $segment->ingestDatastream($ocr);
+
+    drupal_unlink($cropped_file);
+    return $repository->ingestObject($segment);
 }


### PR DESCRIPTION
Can now generate and ingest segments from a newspaper page.

# To test
- Re-provision vagrant
  - The composer_manager dependency will be installed by vagrant.
 - Run the API
   - Note the default port conflicts with the Islandora http port a good alternative is 8008
 - Configure the API in Islandora
   - API host should be your computer's IP **NOT** localhost
   - With vagrant:
     - Set the `NEWSPAPER_NAVIGATOR_HOST` and `NEWSPAPER_NAVIGATOR_PORT` environment variables before provisioning with vagrant.
   - In Islandora:
     - In the [Image segmentation solutionpack admin menu](http://localhost:8000/admin/islandora/solution_pack_config/segmentation) set the values.
- Replace OBJ datastream with a non JP-2 image
  - Since ImageMagick is unable to work with JP-2 images the OBJ datastream must be replaced.
    - Select a page
    - *Manage*
    - *Datastreams*
    - *replace* the OBJ stream
    - Wait until the site gives feedback it can take a while.
 - Extract segments
   - From the selected page
   - *Manage*
   - *Page*
   - *Generate Segments*