### PR TITLE
Bugfix set default api params

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A configuration page can be found at Administration » Islandora » Solution Pac
 The configuration page allows you to set the following parameters:
 
 1. API Host: The hostname where your API is running. For example, `localhost` or `37.53.12.12`.
-2. API Port: The port that your API is running on. For example, `8000`.
+2. API Port: The port that your API is running on. For example, `8008`.
 3. API Key: The API key that your API is using. Can be left blank if the API was not launched with a key.
 4. Confidence Threshold: A number between 0 and 1. All returned segments below this threshold will not be ingested.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,8 +52,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision :shell, inline: "drush --root=/var/www/drupal/ en -u 1 -y composer_manager || echo '##### PLEASE IGNORE THE ERRORS #####' ", :privileged => false
   config.vm.provision :shell, inline: "drush --root=/var/www/drupal/ en -u 1 -y image_segmentation", :privileged => false
-  config.vm.provision :shell, inline: "drush --root=/var/www/drupal/ vset api_host $1", :args => $newspaper_navigator_host, :privileged => false
-  config.vm.provision :shell, inline: "drush --root=/var/www/drupal/ vset api_port $1", :args => $newspaper_navigator_port, :privileged => false
+  config.vm.provision :shell, inline: "drush --root=/var/www/drupal/ vset image_segmentation_api_host $1", :args => $newspaper_navigator_host, :privileged => false
+  config.vm.provision :shell, inline: "drush --root=/var/www/drupal/ vset image_segmentation_api_port $1", :args => $newspaper_navigator_port, :privileged => false
   config.vm.provision :shell, inline: "drush --root=/var/www/drupal/ dl drush_extras", :privileged => false
   config.vm.provision :shell, inline: "drush --root=/var/www/drupal/ block-configure  --module image_segmentation --delta image_segment_list --region sidebar_first", :privileged => false
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -36,14 +36,14 @@
       "image_segmentation_confidence_threshold" => array(
         '#type' => 'textfield',
         '#title' => t('API Confidence Threshold'),
-        '#default_value' => variable_get('image_segmentation_confidence_threshold', '66.6'),
+        '#default_value' => variable_get('image_segmentation_confidence_threshold', '0.6'),
         '#description' => t('Confidence Threshold for API ML results'),
         '#size' => 50,
       ),
       "image_segmentation_timeout" => array(
         '#type' => 'textfield',
         '#title' => t('API Confidence Threshold'),
-        '#default_value' => variable_get('image_segmentation_timeout', '120.0'),
+        '#default_value' => variable_get('image_segmentation_timeout', '60.0'),
         '#description' => t('How long to wait for a response in seconds.'),
         '#size' => 50,
       )

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -117,9 +117,9 @@ function image_segmentation_extract_segments(AbstractObject $object, bool $force
     return FALSE;
   }
 
-  $api_host = variable_get("image_segmentation_api_host");
-  $api_port = variable_get("image_segmentation_api_port");
-  $api_key = variable_get("image_segmentation_api_key", 60.0);
+  $api_host = variable_get("image_segmentation_api_host", "localhost");
+  $api_port = variable_get("image_segmentation_api_port", 8008);
+  $api_key = variable_get("image_segmentation_api_key", "");
   $api_timeout = variable_get("image_segmentation_timeout", 60.0);
   $client = new SegmentationClient("{$api_host}:{$api_port}/api/", $api_timeout, $api_key);
 


### PR DESCRIPTION
Fixes issue where variable_get is does not have a default parameter for the API client. So if an image was segmented before visiting the admin form the API base URI will not be formed correctly.

Also updates default port example in the documentation.