### PR TITLE
Readd generate derivatives

### DIFF
--- a/image_segmentation.module
+++ b/image_segmentation.module
@@ -227,36 +227,72 @@ function image_segmentation_batch_extract_segments_from_page_completed($success,
 /**
  * Implements hook_cmodel_pid_islandora_derivative().
  */
-function image_segmentation_islandora_segmentedImageCModel_islandora_derivative() {
+function image_segmentation_islandora_segmentedImageCModel_islandora_derivative(AbstractObject $object = NULL, array $ds_modified_params = array()) {
   $large_image_module_path = drupal_get_path('module', 'islandora_large_image');
+  $image_segmentation_module_path = drupal_get_path('module', 'image_segmentation');
 
-  return array(
-    array(
-      'source_dsid' => 'OBJ',
-      'destination_dsid' => 'TN',
-      'weight' => 0,
-      'function' => array(
-        'islandora_large_image_create_tn_derivative',
-      ),
-      'file' => "$large_image_module_path/includes/derivatives.inc",
-    ),
-    array(
-      'source_dsid' => 'OBJ',
-      'destination_dsid' => 'JPG',
-      'weight' => 1,
-      'function' => array(
-        'islandora_large_image_create_jpg_derivative',
-      ),
-      'file' => "$large_image_module_path/includes/derivatives.inc",
-    ),
-    array(
-      'source_dsid' => 'OBJ',
-      'destination_dsid' => 'JP2',
-      'weight' => 2,
-      'function' => array(
-        'islandora_large_image_create_jp2_derivative',
-      ),
-      'file' => "$large_image_module_path/includes/derivatives.inc",
-    ),
-  );
+  //If OBJ datastream is of an image type
+  if (isset($object['OBJ']) && strpos(strtolower($object['OBJ']->mimetype), 'image') === 0 ) {
+    if (strtolower($object['OBJ']->mimetype) == 'image/jp2'){
+      return [
+        [
+          'source_dsid' => 'OBJ',
+          'destination_dsid' => 'TN',
+          'weight' => 0,
+          'function' => [
+            'image_segmentation_create_tn_jp2_derivative',
+          ],
+          'file' => "$image_segmentation_module_path/includes/derivatives.inc",
+        ],
+        [
+          'source_dsid' => 'OBJ',
+          'destination_dsid' => 'JPG',
+          'weight' => 1,
+          'function' => [
+            'image_segmentation_create_jpg_jp2_derivative',
+          ],
+          'file' => "$image_segmentation_module_path/includes/derivatives.inc",
+        ],
+        [
+          'source_dsid' => 'OBJ',
+          'destination_dsid' => 'JP2',
+          'weight' => 2,
+          'function' => [
+            'image_segmentation_create_jp2_jp2_derivative',
+          ],
+          'file' => "$image_segmentation_module_path/includes/derivatives.inc",
+        ],
+      ];
+    }
+    return [
+      [
+        'source_dsid' => 'OBJ',
+        'destination_dsid' => 'TN',
+        'weight' => 0,
+        'function' => [
+          'islandora_large_image_create_tn_derivative',
+        ],
+        'file' => "$large_image_module_path/includes/derivatives.inc",
+      ],
+      [
+        'source_dsid' => 'OBJ',
+        'destination_dsid' => 'JPG',
+        'weight' => 1,
+        'function' => [
+          'islandora_large_image_create_jpg_derivative',
+        ],
+        'file' => "$large_image_module_path/includes/derivatives.inc",
+      ],
+      [
+        'source_dsid' => 'OBJ',
+        'destination_dsid' => 'JP2',
+        'weight' => 2,
+        'function' => [
+          'islandora_large_image_create_jp2_derivative',
+        ],
+        'file' => "$large_image_module_path/includes/derivatives.inc",
+      ],
+    ];
+  }
+  return [];
 }

--- a/image_segmentation.module
+++ b/image_segmentation.module
@@ -223,3 +223,40 @@ function image_segmentation_batch_extract_segments_from_page_completed($success,
         );
     }
 }
+
+/**
+ * Implements hook_cmodel_pid_islandora_derivative().
+ */
+function image_segmentation_islandora_segmentedImageCModel_islandora_derivative() {
+  $large_image_module_path = drupal_get_path('module', 'islandora_large_image');
+
+  return array(
+    array(
+      'source_dsid' => 'OBJ',
+      'destination_dsid' => 'TN',
+      'weight' => 0,
+      'function' => array(
+        'islandora_large_image_create_tn_derivative',
+      ),
+      'file' => "$large_image_module_path/includes/derivatives.inc",
+    ),
+    array(
+      'source_dsid' => 'OBJ',
+      'destination_dsid' => 'JPG',
+      'weight' => 1,
+      'function' => array(
+        'islandora_large_image_create_jpg_derivative',
+      ),
+      'file' => "$large_image_module_path/includes/derivatives.inc",
+    ),
+    array(
+      'source_dsid' => 'OBJ',
+      'destination_dsid' => 'JP2',
+      'weight' => 2,
+      'function' => array(
+        'islandora_large_image_create_jp2_derivative',
+      ),
+      'file' => "$large_image_module_path/includes/derivatives.inc",
+    ),
+  );
+}

--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -1,0 +1,84 @@
+<?php
+
+function image_segmentation_create_tn_jp2_derivative(AbstractObject $object, $force = TRUE) {
+  return image_segmentation_create_scaled_jp2_derivative($object, 'TN', 2, 'image/jpeg', $force);
+}
+
+function image_segmentation_create_jpg_jp2_derivative(AbstractObject $object, $force = TRUE) {
+  return image_segmentation_create_scaled_jp2_derivative($object, 'JPG', 100, 'image/jpeg', $force);
+}
+
+function image_segmentation_create_jp2_jp2_derivative(AbstractObject $object, $force = TRUE) {
+  try {
+    image_segmentation_image_add_datastream($object, 'JP2', $object['OBJ']->content, 'image/jp2', "JP2 Datastream");
+    return [
+      'succes' => TRUE,
+      'messages' => [
+        [
+          'message' => t("Created JP2 derivative . "),
+          'type' => 'dsm',
+          'severity' => 'status',
+        ],
+      ],
+    ];
+  } catch (Execption $e) {
+    return [
+      'succes' => TRUE,
+      'messages' => [
+        [
+          'message' => t("Failed to create JP2 derivative . "),
+          'type' => 'watchdog',
+          'severity' => WATCHDOG_ERROR,
+        ],
+      ],
+    ];
+  }
+
+}
+
+function image_segmentation_create_scaled_jp2_derivative(AbstractObject $object, $dsid, $level, $ds_mimetype = 'image/jpeg', $force = TRUE) {
+  try {
+    module_load_include('inc', 'image_segmentation', 'includes/utilities');
+    $ds_content = image_segmentation_scale_jp2($object['OBJ'], $level);
+    image_segmentation_image_add_datastream($object, $dsid, $ds_content, $ds_mimetype, "$dsid Datastream");
+    return [
+      'succes' => TRUE,
+      'messages' => [
+        [
+          'message' => t("Created $dsid derivative . "),
+          'type' => 'dsm',
+          'severity' => 'status',
+        ],
+      ],
+    ];
+  } catch (Execption $e) {
+    return [
+      'succes' => TRUE,
+      'messages' => [
+        [
+          'message' => t("Failed to create $dsid derivative . "),
+          'type' => 'watchdog',
+          'severity' => WATCHDOG_ERROR,
+        ],
+      ],
+    ];
+  }
+}
+
+function image_segmentation_image_add_datastream(AbstractObject $object, $dsid, $content, $mimetype, $label) {
+  $exists = isset($object[$dsid]);
+  if ($exists) {
+    $ds = $object[$dsid];
+  }
+  else {
+    $ds = $object->constructDatastream($dsid, 'M');
+    $ds->label = $label;
+    $ds->mimeType = $mimetype;
+  }
+
+  $ds->content = $content;
+
+  if (!$exists) {
+    $object->ingestDatastream($ds);
+  }
+}

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -293,6 +293,35 @@ function image_segmentation_crop_jp2(AbstractDatastream &$source, AbstractDatast
 
 }
 
+
+function image_segmentation_scale_jp2(AbstractDatastream &$datastream, int $level){
+  $client = new Client(
+    ['base_uri' => variable_get('djatoka_base_uri','http://localhost:8080/adore-djatoka/')]
+  );
+  $url = url("islandora/object/{$datastream->parent->id}/datastream/{$datastream->id}/view",
+    [
+      'absolute' => TRUE,
+      //      'query' => array(
+      //        'token' => $token,
+      //      ),
+      'language' => language_default(),
+      'https' => FALSE,
+    ]
+  );
+
+  $query = [
+    'url_ver' => 'Z39.88-2004',
+    'rft_id' => $url,
+    'svc_id' => 'info:lanl-repo/svc/getRegion',
+    'svc_val_fmt' => 'info:ofi/fmt:kev:mtx:jpeg2000',
+    'svc.format' => 'image/jpeg',
+      'svc.level' => $level,
+  ];
+
+  $response = $client->get('resolver', ['query' => $query]);
+  return $response->getBody();
+}
+
 /**
  * Hits a dummy endpoint in the API to see if it is accessible.
  *


### PR DESCRIPTION
## Changes
Adds support for derivative generation for both tiffs and jp2.

## To test 
1. Generate segments for page with jp2 OBJ datastream.
  a. Verify TN datastream properly generated for each segment 
  a. Verify JPG datastream properly generated for each segment 
  a. Verify JP2 datastream properly generated for each segment 
1. Generate segments for page with tiff OBJ datastream.
  a. Verify TN datastream properly generated for each segment 
  a. Verify JPG datastream properly generated for each segment 
  a. Verify JP2 datastream properly generated for each segment 